### PR TITLE
Add backend support for latexdiff

### DIFF
--- a/setup-chroot.sh
+++ b/setup-chroot.sh
@@ -143,7 +143,7 @@ echo "Running installer"
 
 chroot /var/snap/md2pdf-webserver/common/texlive-chroot wrapper 'update-gsfontmap'
 chroot /var/snap/md2pdf-webserver/common/texlive-chroot wrapper 'install-tl-unx/install-tl -profile install-tl-unx/md2pdf-texlive.profile'
-chroot /var/snap/md2pdf-webserver/common/texlive-chroot wrapper 'tlmgr install datetime fmtcount enumitem soul framed'
+chroot /var/snap/md2pdf-webserver/common/texlive-chroot wrapper 'tlmgr install datetime fmtcount enumitem soul framed changebar'
 
 
 echo "Cleaning up"


### PR DESCRIPTION
Closes #6
This commit introduces a number of changes to accept and use the
"compare mode" implementation of the md2pdf-client. It firstly looks for
the relevant HTTP header, and if found then looks for MD files with
".old" and ".new" in the filenames. It takes these, runs it through a
string replace filter (in case different options are desired for the
compared version, e.g. TOC doesn't work very well, so it can be removed)
and then finally it creates two LaTeX files, runs latexdiff, and
produces the PDF for return to the client.