### PR TITLE
Use bindfs for /dev

### DIFF
--- a/md2pdf_webserver.py
+++ b/md2pdf_webserver.py
@@ -208,7 +208,7 @@ def main():
                 static_content_error = True
                 logging.error("Static content '%s' was not found in '%s', this might cause Pandoc to fail", content, static_path)
         if static_content_error and running_as_snap:
-            logging.error("Note that md2md2pdf_webserver is running as a Snap package - it might be confined and unable to access absolute paths")
+            logging.error("Note that md2pdf_webserver is running as a Snap package - it might be confined and unable to access absolute paths")
 
         ## Remove old temporary files
         logging.info("Deleting files in '" + def_tempdir + "'")
@@ -218,6 +218,11 @@ def main():
         except:
             logging.warning("Unable to delete and re-create temporary directory")
             raise
+
+        ## Start the bind mount for /dev
+        arg = 'bindfs ' + '/dev/ ' + os.path.join(chroot_path, 'dev-real')
+        p = subprocess.Popen(arg, shell=True)
+        p.wait()
 
         ## Start the CherryPy server
         def_listen = args.listen

--- a/setup-chroot.sh
+++ b/setup-chroot.sh
@@ -18,6 +18,7 @@ echo "Creating basic folder structure"
 mkdir bin
 mkdir usr
 mkdir dev
+mkdir dev-real
 mkdir etc
 mkdir lib
 mkdir tmp
@@ -116,14 +117,12 @@ then
     cp -a ${SNAP}/bin/pandoc-crossref bin/
 fi
 
+echo "Mounting /dev inside chroot"
+bindfs /dev/ dev-real/
 
-echo "Setting up a small amount of entropy into /dev/random"
-echo "(this will be faster if you use the keyboard and mouse!)"
-
-# Hide the output from dd, it's not really helpful in this case
-dd if=/dev/random of=dev/random bs=1 count=128 1> /dev/null
-dd if=/dev/urandom of=dev/urandom bs=1 count=128 1> /dev/null
-
+echo "Linking /dev/random and /dev/urandom inside chroot"
+ln -s dev-real/random dev/random
+ln -s dev-real/urandom dev/urandom
 
 echo "Mounting TeX Live ISO installer"
 


### PR DESCRIPTION
Previously, the installer set up static files inside the chroot for
/dev/random and /dev/urandom - this was because the chroot is unable to
access the real devices on the host. Typically when using a chroot this
would be dealt with using a 'bind' mount - but this cannot be done
inside a Snap package, so a static file was used.
This commit changes the chroot setup to instead use a FUSE bind mount.